### PR TITLE
fix: removed deprecated container registry in favor of artifact regis…

### DIFF
--- a/docs/semana_3/tutorial_4.md
+++ b/docs/semana_3/tutorial_4.md
@@ -78,7 +78,7 @@ Dado que su código ha cambiado, vuelva a crear la imagen para el servicio de ad
 
 ### 6. Publicar imágenes
 
-Una vez con las imágenes, publíquelas en algún [Container Registry](https://www.redhat.com/en/topics/cloud-native-apps/what-is-a-container-registry){:target="_blank"}. Si usa GCP puede seguir las siguientes [instrucciones](https://cloud.google.com/container-registry/docs/pushing-and-pulling){:target="_blank"}.
+Una vez con las imágenes, publíquelas en algún [Container Registry](https://www.redhat.com/en/topics/cloud-native-apps/what-is-a-container-registry){:target="_blank"}. Si usa GCP puede seguir las siguientes [instrucciones](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling){:target="_blank"}.
 
 ### 7. Despliegue su servicio
 


### PR DESCRIPTION
…try in GCP

## Describa el cambio
+ Se reemplazó la URL que apunta a container registry a artifact registry que está marcado para shutdown en marzo
## Razonamiento pedagógico
+ Utilizar los recursos actualizados y blindados a futuro
+ Se evita perder imágenes hechas en el curso

### Lista de chequeo
- [ ] Ejecuté el proyecto de forma local o usando Gitpod
- [ ] Corrí todas las pruebas
- [ ] Agregué o modifiqué pruebas
